### PR TITLE
리스트 순서가 반대로 나타나는 현상 해결과 페이지 시작을 1로 바꾸는 수정 작업

### DIFF
--- a/NotificationSite/src/main/java/com/NotificationSite/NotificationSite/controller/NoticeController.java
+++ b/NotificationSite/src/main/java/com/NotificationSite/NotificationSite/controller/NoticeController.java
@@ -45,7 +45,7 @@ public class NoticeController {
     }
 
     //공지사항 상세
-    @GetMapping("/noticeview")
+    @GetMapping(value = "/noticeview/{id}")
     public String noticeView(Model model, Integer id){
         model.addAttribute("Notice",noticeService.noticeView(id));
         return "noticeview";

--- a/NotificationSite/src/main/java/com/NotificationSite/NotificationSite/service/NoticeService.java
+++ b/NotificationSite/src/main/java/com/NotificationSite/NotificationSite/service/NoticeService.java
@@ -52,9 +52,7 @@ public class NoticeService {
 
 
     public Page<Notice> getList(int page) {
-        List<Sort.Order> sorts = new ArrayList<>();
-        sorts.add(Sort.Order.desc("createDate"));
-        Pageable pageable = PageRequest.of(page, 10, Sort.by(sorts));
+        Pageable pageable = PageRequest.of(page, 10);
         return this.noticeRepository.findAll(pageable);
     }
 }

--- a/NotificationSite/src/main/resources/templates/notice_list.html
+++ b/NotificationSite/src/main/resources/templates/notice_list.html
@@ -41,9 +41,9 @@
       </thead>
       <tbody>
         <tr class="text-center" th:each="notice, loop : ${paging}">
-          <td th:text="${paging.getTotalElements - (paging.number * paging.size) - loop.index}"></td>
+          <td th:text="${loop.count}"></td>
           <td class="text-start">
-            <a th:href="@{|/notice/noticeview/${notice.id}|}" th:text="${notice.meetSubject}"></a>
+            <a th:href="@{/notice/noticeview/(id)(id=${notice.id})}" th:text="${notice.meetSubject}"></a>
           </td>
           <td><span th:if="${notice.siteUser != null}" th:text="${notice.siteUser.username}"></span></td>
           <td th:text="${notice.meetDay}"></td>
@@ -60,7 +60,7 @@
           <span>이전</span>
         </a>
       </li>
-      <li th:each="page: ${#numbers.sequence(0, paging.totalPages-1)}"
+      <li th:each="page: ${#numbers.sequence(1, paging.totalPages)}"
           th:if="${page >= paging.number-5 and page <= paging.number+5}"
           th:classappend="${page == paging.number} ? 'active'"
           class="page-item">


### PR DESCRIPTION
리스트에서 상세페이지로 넘어가도록 수정